### PR TITLE
Fix websocket command streaming

### DIFF
--- a/backend/codex_agent/azure_queue.py
+++ b/backend/codex_agent/azure_queue.py
@@ -75,6 +75,19 @@ class AzureQueueManager:
             return payload
         return None
 
+    def peek_command(self) -> Optional[Dict]:
+        """Peek at the next command in the queue without removing it"""
+        try:
+            messages = self.queue_client.peek_messages(max_messages=1)
+            for msg in messages:
+                try:
+                    return json.loads(msg.content)
+                except json.JSONDecodeError:
+                    continue
+        except Exception:
+            pass
+        return None
+
     def receive_response(self, timeout: int = 30) -> Optional[Dict]:
         """Receive a single response message from the response queue"""
         messages = self.response_queue.receive_messages(


### PR DESCRIPTION
## Summary
- peek commands from Azure queue so that the container still receives them
- keep track of processed message IDs in websocket handler

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877227bf3c88325801b559ee194805d